### PR TITLE
Small edit to prevent the last saved query/mutation from executing ...

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,7 +34,7 @@ body,
     }
 }
 
-#url-box, #url-save-button {
+#url-box {
     height: 30px;
     box-sizing: border-box;
     margin: 3px auto;
@@ -44,19 +44,19 @@ body,
     width: 500px;
     margin-right: 2px;
     border-radius: 4px;
-    margin-right: 2px;
     padding: 0 4px;
-    border: 1px none;
-    border-style: inset;
+    border: 1px inset;
     color: #555;
-}
-
-#url-save-button {
-    padding: 6px 12px;
 }
 
 #no-endpoint {
     margin: 4em auto;
     text-align: center;
     font-size: 16px;
+}
+
+#typing {
+    white-space: nowrap;
+    align-self: center;
+    color: gray;
 }

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -119,17 +119,6 @@ class GraphiQLExtension extends React.Component {
         const setState = this.setState.bind(this);
         const currState = this.state;
 
-        // If we have changed endpoints just now...
-        if (endpoint !== currState.currEndpoint) {
-            // then we shall re-execute the query after render
-            setTimeout(() => {
-                const buttons = document.getElementsByClassName('execute-button');
-                for (const button of buttons) {//
-                    button.click()
-                }
-            }, 500);
-        }
-        
         chrome.storage.local.set(
             {'endpoint': newEndpoint},
             () => {

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -1,73 +1,74 @@
-import React, { useState } from 'react';
+import React, {useState, useEffect, useMemo} from 'react';
 import ReactDOM from 'react-dom';
 import GraphiQL from 'graphiql';
+import useDebounce from './use-debounce';
 import 'graphiql/graphiql.css';
 
+function graphQLFetcher(endpoint) {
+    return function (graphQLParams) {
+        return fetch(endpoint, {
+            method: 'post',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+        }).then(response => response.json());
+    }
+}
+
 function GraphiQLExtension(props) {
-    const [textValue, setTextValue] = useState(props.endpoint);
-    const [currEndpoint, setCurrEndpoint] = useState(props.endpoint);
+    const [endpoint, setEndpoint] = useState(props.endpoint);
+    const [isTyping, setIsTyping] = useState(false);
+    const debouncedEndpoint = useDebounce(endpoint, 500);
 
-    const graphQLFetcher = (endpoint) => {
-        return function (graphQLParams) {
-            return fetch(endpoint, {
-                method: 'post',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify(graphQLParams),
-                credentials: 'include',
-            }).then(response => response.json());
-        }
-    }
-    
-    const handleKeyDown = (e) => {
-        if (e.key === 'Enter') {
-            setEndpoint();
-        }
-    }
+    // Store endpoint in local storage only after debounced
+    useEffect(
+        () => {
+            setIsTyping(false);
+            chrome.storage.local.set({
+                endpoint: debouncedEndpoint,
+            });
+        },
+        [debouncedEndpoint],
+    );
 
-    const setEndpoint = () => {
-        chrome.storage.local.set(
-            {'endpoint': textValue},
-            () => {
-                if (!chrome.runtime.lastError) {
-                    // Move current endpoint to previous, and set current endpoint to new.
-                    setCurrEndpoint(textValue);
-                }
-            },
-        );
+    function changed(event) {
+        setIsTyping(true);
+        const newEndpoint = event.target.value;
+        setEndpoint(newEndpoint);
     }
 
-    const updateEndpoint = (e) => {
-        setTextValue(e.target.value);
-    }
+    // Only re-render GraphiQL when debounced endpoint actually changed, otherwise
+    // it would re-render and fetch introspection queries too often
+    const graphiQL = useMemo(() => {
+        return debouncedEndpoint ? (
+            <GraphiQL
+                id="graphiql"
+                fetcher={graphQLFetcher(debouncedEndpoint)}
+            />
+        ) : (
+            <p id="no-endpoint">Set a non empty endpoint above</p>
+        )
+
+    }, [debouncedEndpoint]);
 
     return (
-      <div id="application">
-        <div id="url-bar" className="graphiql-container">
-          <input
-            type="text"
-            id="url-box"
-            defaultValue={props.endpoint}
-            onChange={updateEndpoint}
-            onKeyDown={handleKeyDown}
-          />
-          <a id="url-save-button" className="toolbar-button" onClick={setEndpoint}>
-            Set endpoint
-          </a>
+        <div id="application">
+            <div id="url-bar" className="graphiql-container">
+                <input
+                    type="url"
+                    id="url-box"
+                    defaultValue={props.endpoint}
+                    onChange={changed}
+                />
+                <div id="typing" style={isTyping ? {} : {visibility: 'hidden'}}>Typing ...</div>
+            </div>
+            {graphiQL}
         </div>
-        {currEndpoint ? (
-          <GraphiQL
-            id="graphiql"
-            fetcher={graphQLFetcher(currEndpoint)}
-          />
-        ) : (
-          <p id="no-endpoint">Set a non empty endpoint above</p>
-        )}
-      </div>
     );
 }
 
 chrome.storage.local.get('endpoint', (storage) =>
-    // Render <GraphiQL /> into the container.
+    // Render <GraphiQLExtension /> into the container.
     ReactDOM.render(
         <GraphiQLExtension endpoint={storage.endpoint}/>,
         document.getElementById('react-container'),

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -90,17 +90,6 @@ class GraphiQLExtension extends React.Component {
                 <p id="no-endpoint">Set a non empty endpoint above</p>;
         }
 
-        // If we have changed endpoints just now...
-        if (this.state.currEndpoint !== this.state.prevEndpoint) {
-            // then we shall re-execute the query after render
-            setTimeout(() => {
-                const buttons = document.getElementsByClassName('execute-button');
-                for (const button of buttons) {//
-                    button.click()
-                }
-            }, 500);
-        }
-
         return (
             <div id="application">
                 <div id="url-bar" className="graphiql-container">
@@ -130,6 +119,17 @@ class GraphiQLExtension extends React.Component {
         const setState = this.setState.bind(this);
         const currState = this.state;
 
+        // If we have changed endpoints just now...
+        if (endpoint !== currState.currEndpoint) {
+            // then we shall re-execute the query after render
+            setTimeout(() => {
+                const buttons = document.getElementsByClassName('execute-button');
+                for (const button of buttons) {//
+                    button.click()
+                }
+            }, 500);
+        }
+        
         chrome.storage.local.set(
             {'endpoint': newEndpoint},
             () => {

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -1,141 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import GraphiQL from 'graphiql';
 import 'graphiql/graphiql.css';
 
-// Buffer for endpoint entry value
-let endpoint;
+function GraphiQLExtension(props) {
+    const [textValue, setTextValue] = useState(props.endpoint);
+    const [currEndpoint, setCurrEndpoint] = useState(props.endpoint);
 
-// Parse the search string to get url parameters.
-const search = window.location.search;
-let parameters = {};
-search.substr(1).split('&').forEach(function (entry) {
-    const eq = entry.indexOf('=');
-    if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-            decodeURIComponent(entry.slice(eq + 1));
-    }
-});
-
-// if variables was provided, try to format it.
-if (parameters.variables) {
-    try {
-        parameters.variables =
-            JSON.stringify(JSON.parse(parameters.variables), null, 2);
-    } catch (e) {
-        // Do nothing, we want to display the invalid JSON as a string, rather
-        // than present an error.
-    }
-}
-
-// When the query and variables string is edited, update the URL bar so
-// that it can be easily shared
-function onEditQuery(newQuery) {
-    parameters.query = newQuery;
-    updateURL();
-}
-
-function onEditVariables(newVariables) {
-    parameters.variables = newVariables;
-    updateURL();
-}
-
-function updateURL() {
-    let newSearch = '?' + Object.keys(parameters).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-            encodeURIComponent(parameters[key]);
-    }).join('&');
-    history.replaceState(null, null, newSearch);
-}
-
-// Defines a GraphQL fetcher using the fetch API.
-function graphQLFetcher(endpoint) {
-    return function (graphQLParams) {
-        return fetch(endpoint, {
-            method: 'post',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(graphQLParams),
-            credentials: 'include',
-        }).then(response => response.json());
-    }
-}
-
-class GraphiQLExtension extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            prevEndpoint: null,
-            currEndpoint: this.props.endpoint,
-        };
-
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-        this.setEndpoint = this.setEndpoint.bind(this);
-        this.updateEndpoint = this.updateEndpoint.bind(this);
-    }
-
-    render() {
-        const endpoint = this.state.currEndpoint;
-        let graphqlConsole = null;
-        if (endpoint) {
-            graphqlConsole =
-                <GraphiQL
-                    id="graphiql"
-                    fetcher={graphQLFetcher(endpoint)}
-                    query={parameters.query}
-                    variables={parameters.variables}
-                    onEditQuery={onEditQuery}
-                    onEditVariables={onEditVariables}/>;
-        } else {
-            graphqlConsole =
-                <p id="no-endpoint">Set a non empty endpoint above</p>;
+    const graphQLFetcher = (endpoint) => {
+        return function (graphQLParams) {
+            return fetch(endpoint, {
+                method: 'post',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(graphQLParams),
+                credentials: 'include',
+            }).then(response => response.json());
         }
-
-        return (
-            <div id="application">
-                <div id="url-bar" className="graphiql-container">
-                    <input type="text"
-                           id="url-box"
-                           defaultValue={endpoint}
-                           onChange={this.updateEndpoint}
-                           onKeyDown={this.handleKeyDown}/>
-                    <a id="url-save-button" className="toolbar-button" onClick={this.setEndpoint}>
-                        Set endpoint
-                    </a>
-                </div>
-                {graphqlConsole}
-            </div>
-        );
     }
-
-    handleKeyDown(e) {
+    
+    const handleKeyDown = (e) => {
         if (e.key === 'Enter') {
-            this.updateEndpoint(e);
-            this.setEndpoint();
+            setEndpoint();
         }
     }
 
-    setEndpoint() {
-        const newEndpoint = endpoint;
-        const setState = this.setState.bind(this);
-        const currState = this.state;
-
+    const setEndpoint = () => {
         chrome.storage.local.set(
-            {'endpoint': newEndpoint},
+            {'endpoint': textValue},
             () => {
                 if (!chrome.runtime.lastError) {
                     // Move current endpoint to previous, and set current endpoint to new.
-                    setState({
-                        prevEndpoint: currState.currEndpoint,
-                        currEndpoint: newEndpoint,
-                    });
+                    setCurrEndpoint(textValue);
                 }
             },
         );
     }
 
-    updateEndpoint(e) {
-        endpoint = e.target.value;
+    const updateEndpoint = (e) => {
+        setTextValue(e.target.value);
     }
+
+    return (
+      <div id="application">
+        <div id="url-bar" className="graphiql-container">
+          <input
+            type="text"
+            id="url-box"
+            defaultValue={props.endpoint}
+            onChange={updateEndpoint}
+            onKeyDown={handleKeyDown}
+          />
+          <a id="url-save-button" className="toolbar-button" onClick={setEndpoint}>
+            Set endpoint
+          </a>
+        </div>
+        {currEndpoint ? (
+          <GraphiQL
+            id="graphiql"
+            fetcher={graphQLFetcher(currEndpoint)}
+          />
+        ) : (
+          <p id="no-endpoint">Set a non empty endpoint above</p>
+        )}
+      </div>
+    );
 }
 
 chrome.storage.local.get('endpoint', (storage) =>

--- a/js/use-debounce.jsx
+++ b/js/use-debounce.jsx
@@ -1,0 +1,34 @@
+import React, {useState, useEffect} from 'react';
+
+export default function useDebounce(value, delay) {
+    // State and setters for debounced value
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(
+        () => {
+            // Set debouncedValue to value (passed in) after the specified delay
+            const handler = setTimeout(() => {
+                setDebouncedValue(value);
+            }, delay);
+
+            // Return a cleanup function that will be called every time ...
+            // ... useEffect is re-called. useEffect will only be re-called ...
+            // ... if value changes (see the inputs array below).
+            // This is how we prevent debouncedValue from changing if value is ...
+            // ... changed within the delay period. Timeout gets cleared and restarted.
+            // To put it in context, if the user is typing within our app's ...
+            // ... search box, we don't want the debouncedValue to update until ...
+            // ... they've stopped typing for more than 500ms.
+            return () => {
+                clearTimeout(handler);
+            };
+        },
+        // Only re-call effect if value changes
+        // You could also add the "delay" var to inputs array if you ...
+        // ... need to be able to change that dynamically.
+        [value],
+    );
+
+    return debouncedValue;
+}
+


### PR DESCRIPTION
when the add-in is loaded.

I wanted to change this because I was debugging a mutation, and when I loaded the add-in again later, The previous mutation automatically executed. This behavior can have some pretty serious consequences if the mutation previously run modifies any significant amount of data, or kicks off some long running process.

The behavior of executing the last query or mutation on change of endpoint is unaffected.